### PR TITLE
feat: Add CSV export format support

### DIFF
--- a/crashvault/commands/export_cmd.py
+++ b/crashvault/commands/export_cmd.py
@@ -1,4 +1,4 @@
-import click, json
+import click, json, csv
 from datetime import datetime, timezone
 from pathlib import Path
 from ..core import load_issues, load_events
@@ -7,21 +7,85 @@ from ..rich_utils import get_console
 console = get_console()
 
 
+def issues_to_csv(issues, writer):
+    """Write issues to CSV format."""
+    fieldnames = ["id", "title", "status", "created_at", "resolved_at", "event_count", "tags"]
+    writer.writeheader()
+    for issue in issues:
+        row = {
+            "id": issue.get("id", ""),
+            "title": issue.get("title", ""),
+            "status": issue.get("status", ""),
+            "created_at": issue.get("created_at", ""),
+            "resolved_at": issue.get("resolved_at", ""),
+            "event_count": len(issue.get("events", [])),
+            "tags": ", ".join(issue.get("tags", [])),
+        }
+        writer.writerow(row)
+
+
+def events_to_csv(events, writer):
+    """Write events to CSV format."""
+    fieldnames = ["id", "issue_id", "message", "level", "timestamp", "source", "tags", "context"]
+    writer.writeheader()
+    for event in events:
+        row = {
+            "id": event.get("id", ""),
+            "issue_id": event.get("issue_id", ""),
+            "message": event.get("message", ""),
+            "level": event.get("level", ""),
+            "timestamp": event.get("timestamp", ""),
+            "source": event.get("source", ""),
+            "tags": ", ".join(event.get("tags", [])),
+            "context": json.dumps(event.get("context", {})),
+        }
+        writer.writerow(row)
+
+
+def export_as_csv(issues, events, output_path):
+    """Export issues and events to CSV format."""
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        # Write issues section
+        f.write("# Issues\n")
+        issues_writer = csv.DictWriter(f, fieldnames=["id", "title", "status", "created_at", "resolved_at", "event_count", "tags"])
+        issues_to_csv(issues, issues_writer)
+        
+        # Write blank line separator
+        f.write("\n")
+        
+        # Write events section
+        f.write("# Events\n")
+        events_writer = csv.DictWriter(f, fieldnames=["event_id", "issue_id", "message", "level", "timestamp", "source", "tags", "context"])
+        events_to_csv(events, events_writer)
+
+
 @click.command()
-@click.option("--output", type=click.Path(dir_okay=False, writable=True, resolve_path=True), help="Output file (JSON). Defaults to stdout")
-def export(output):
-    """Export all issues and events to JSON."""
-    payload = {
-        "version": 1,
-        "exported_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "issues": load_issues(),
-        "events": load_events(),
-    }
-    data = json.dumps(payload, indent=2)
-    if output:
-        Path(output).write_text(data)
+@click.option("--output", type=click.Path(dir_okay=False, writable=True, resolve_path=True), help="Output file. Defaults to stdout")
+@click.option("--format", type=click.Choice(["json", "csv"], case_sensitive=False), default="json", help="Export format (json or csv)")
+def export(output, format):
+    """Export all issues and events to JSON or CSV format."""
+    issues = load_issues()
+    events = load_events()
+    
+    if format == "csv":
+        if not output:
+            # Cannot output CSV to stdout with proper formatting, require output file
+            console.print("[error]CSV format requires an output file. Use --output <filename>[/error]")
+            return
+        
+        export_as_csv(issues, events, output)
         console.print(f"[success]Exported to[/success] [highlight]{output}[/highlight]")
-    else:
-        click.echo(data)
-
-
+    
+    else:  # JSON format (default)
+        payload = {
+            "version": 1,
+            "exported_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "issues": issues,
+            "events": events,
+        }
+        data = json.dumps(payload, indent=2)
+        if output:
+            Path(output).write_text(data)
+            console.print(f"[success]Exported to[/success] [highlight]{output}[/highlight]")
+        else:
+            click.echo(data)

--- a/crashvault/commands/export_cmd.py
+++ b/crashvault/commands/export_cmd.py
@@ -26,16 +26,16 @@ def issues_to_csv(issues, writer):
 
 def events_to_csv(events, writer):
     """Write events to CSV format."""
-    fieldnames = ["id", "issue_id", "message", "level", "timestamp", "source", "tags", "context"]
+    fieldnames = ["event_id", "issue_id", "message", "level", "timestamp", "source", "tags", "context"]
     writer.writeheader()
     for event in events:
         row = {
-            "id": event.get("id", ""),
+            "event_id": event.get("event_id", ""),
             "issue_id": event.get("issue_id", ""),
             "message": event.get("message", ""),
             "level": event.get("level", ""),
             "timestamp": event.get("timestamp", ""),
-            "source": event.get("source", ""),
+            "source": event.get("source", event.get("host", "")),
             "tags": ", ".join(event.get("tags", [])),
             "context": json.dumps(event.get("context", {})),
         }
@@ -71,7 +71,7 @@ def export(output, format):
         if not output:
             # Cannot output CSV to stdout with proper formatting, require output file
             console.print("[error]CSV format requires an output file. Use --output <filename>[/error]")
-            return
+            raise click.Abort()
         
         export_as_csv(issues, events, output)
         console.print(f"[success]Exported to[/success] [highlight]{output}[/highlight]")

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -235,6 +235,78 @@ class TestImportCommand:
         assert ids == [1, 2]
 
 
+class TestExportCSVCommand:
+    """Tests for the CSV export functionality."""
+
+    def test_export_csv_format_option(self, crashvault_home, cli_runner, sample_issues, sample_events, tmp_path):
+        """Export should support --format csv option."""
+        from crashvault.cli import cli
+
+        output_file = tmp_path / "export.csv"
+        result = cli_runner.invoke(cli, ["export", "--output", str(output_file), "--format", "csv"])
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+        content = output_file.read_text()
+        # Should contain issues section
+        assert "# Issues" in content
+        # Should contain events section
+        assert "# Events" in content
+
+    def test_export_csv_has_issue_headers(self, crashvault_home, cli_runner, sample_issues, sample_events, tmp_path):
+        """CSV export should have proper headers for issues."""
+        from crashvault.cli import cli
+
+        output_file = tmp_path / "export.csv"
+        cli_runner.invoke(cli, ["export", "--output", str(output_file), "--format", "csv"])
+
+        content = output_file.read_text()
+        # Check for expected column headers
+        assert "id,title,status,created_at,resolved_at,event_count,tags" in content
+
+    def test_export_csv_has_event_headers(self, crashvault_home, cli_runner, sample_issues, sample_events, tmp_path):
+        """CSV export should have proper headers for events."""
+        from crashvault.cli import cli
+
+        output_file = tmp_path / "export.csv"
+        cli_runner.invoke(cli, ["export", "--output", str(output_file), "--format", "csv"])
+
+        content = output_file.read_text()
+        # Check for expected column headers
+        assert "id,issue_id,message,level,timestamp,source,tags,context" in content
+
+    def test_export_csv_requires_output_file(self, crashvault_home, cli_runner, sample_issues):
+        """CSV export should require an output file."""
+        from crashvault.cli import cli
+
+        result = cli_runner.invoke(cli, ["export", "--format", "csv"])
+
+        assert result.exit_code != 0
+        assert "requires an output file" in result.output
+
+    def test_csv_contains_issue_data(self, crashvault_home, cli_runner, sample_issues, sample_events, tmp_path):
+        """CSV export should contain issue data."""
+        from crashvault.cli import cli
+
+        output_file = tmp_path / "export.csv"
+        cli_runner.invoke(cli, ["export", "--output", str(output_file), "--format", "csv"])
+
+        content = output_file.read_text()
+        # Should contain at least one issue
+        assert content.count("\n") > 5  # Headers + at least one issue row
+
+    def test_csv_format_case_insensitive(self, crashvault_home, cli_runner, sample_issues, sample_events, tmp_path):
+        """CSV format option should be case insensitive."""
+        from crashvault.cli import cli
+
+        output_file = tmp_path / "export.csv"
+        result = cli_runner.invoke(cli, ["export", "--output", str(output_file), "--format", "CSV"])
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+
 class TestExportImportRoundtrip:
     """Tests for export/import roundtrip scenarios."""
 


### PR DESCRIPTION
## Summary
This PR adds CSV export format support to the `crashvault export` command, addressing issue #5.

## Changes
- Added `--format` option with choices for 'json' (default) and 'csv'
- Created CSV generator functions for issues and events
- Issues CSV includes headers: id, title, status, created_at, resolved_at, event_count, tags
- Events CSV includes headers: id, issue_id, message, level, timestamp, source, tags, context
- CSV format requires output file due to proper formatting needs

## Usage
```bash
# Export to CSV format
crashvault export --output errors.csv --format csv

# Export to JSON format (default behavior unchanged)
crashvault export --output backup.json
crashvault export --output backup.json --format json
```